### PR TITLE
Fix a bug of operator precedence in LP selection

### DIFF
--- a/Fitter/partiallyMerged/runSF_nanoAOD.py
+++ b/Fitter/partiallyMerged/runSF_nanoAOD.py
@@ -1091,7 +1091,7 @@ class initialiseFits:
              combData_p_f.add(RooArgSet(rrv_mass_j,category_p_f),tmp_event_weight)
           
           # TOTAL category (no Tau21 )
-          if (discriminantCut == 2 or discriminantCut == 1 or discriminantCut == 0) and (rrv_mass_j.getMin() < tmp_jet_mass < rrv_mass_j.getMax())
+          if (discriminantCut == 2 or discriminantCut == 1 or discriminantCut == 0) and (rrv_mass_j.getMin() < tmp_jet_mass < rrv_mass_j.getMax()): 
               rrv_mass_j.setVal(tmp_jet_mass)
 
               if tmp_jet_mass >= self.mj_signal_min and tmp_jet_mass <self.mj_signal_max :

--- a/Fitter/partiallyMerged/runSF_nanoAOD.py
+++ b/Fitter/partiallyMerged/runSF_nanoAOD.py
@@ -1091,8 +1091,7 @@ class initialiseFits:
              combData_p_f.add(RooArgSet(rrv_mass_j,category_p_f),tmp_event_weight)
           
           # TOTAL category (no Tau21 )
-          if discriminantCut == 2 or discriminantCut == 1 or discriminantCut == 0 and (rrv_mass_j.getMin() < tmp_jet_mass < rrv_mass_j.getMax()):   
-
+          if (discriminantCut == 2 or discriminantCut == 1 or discriminantCut == 0) and (rrv_mass_j.getMin() < tmp_jet_mass < rrv_mass_j.getMax())
               rrv_mass_j.setVal(tmp_jet_mass)
 
               if tmp_jet_mass >= self.mj_signal_min and tmp_jet_mass <self.mj_signal_max :


### PR DESCRIPTION
Critical bug in LP selection during workspace creation. According to this: https://www.programiz.com/python-programming/precedence-associativity
the operator precedence in Python would make an odd selection for the LP category before this fix. 
This is a critical bug, as it may affect the way the scale factors were obtained. 